### PR TITLE
Draft about a proposal for nested multiline imports

### DIFF
--- a/importanize/formatters.py
+++ b/importanize/formatters.py
@@ -7,133 +7,160 @@ import re
 
 
 class Formatter(object):
+    """Parent class for all formatters
+
+    Parameters
+    ----------
+    statement : ImportStatement instance
+
+    """
     def __init__(self, statement):
         self.statement = statement
 
+    def init(self):
+        """Rename some statement attributes to simplify code."""
+        self.leafs = self.statement.unique_leafs
+        self.stem = self.statement.stem
+        self.comments = self.statement.comments
+        self.string = self.statement.as_string()
+        self.file_artifacts = self.statement.file_artifacts.get('sep', '\n')
+
+    def get_normalized(self, i):
+        return map(operator.attrgetter('normalized'), i)
+
+
+
 
 class IndentWithTabsFormatter(Formatter):
+    """Default formatter used to organize long imports
+
+    Imports are added one by line preceded by 4 spaces, here's a sample output:
+
+    from other.package.subpackage.module.submodule import (  # noqa
+        CONSTANT,
+        Klass,
+        bar,
+        foo,
+        rainbows,
+    )
+    """
+
     def format(self):
-        leafs = self.statement.unique_leafs
-        string = self.statement.as_string()
-        get_normalized = lambda i: map(
-            operator.attrgetter('normalized'), i
-        )
-
-        all_comments = (
-            self.statement.comments + list(itertools.chain(
-                *list(map(operator.attrgetter('comments'), leafs))
-            ))
-        )
-
-        if len(all_comments) == 1:
-            string += '  # {}'.format(' '.join(get_normalized(all_comments)))
-
-        if any((len(string) > 80 and len(leafs) > 1,
-                len(all_comments) > 1)):
-            sep = '{}    '.format(self.statement.file_artifacts.get('sep',
-                                                                    '\n'))
-
-            string = 'from {} import ('.format(self.statement.stem)
-
-            if self.statement.comments:
-                string += '  # {}'.format(' '.join(
-                    get_normalized(self.statement.comments)
-                ))
-
-            for leaf in leafs:
-                string += sep
-
-                first_comments = list(filter(
-                    lambda i: i.is_comment_first,
-                    leaf.comments
-                ))
-                if first_comments:
-                    string += sep.join(
-                        '# {}'.format(i)
-                        for i in get_normalized(first_comments)
-                    ) + sep
-
-                string += '{},'.format(leaf.as_string())
-
-                inline_comments = list(filter(
-                    lambda i: not i.is_comment_first,
-                    leaf.comments
-                ))
-                if inline_comments:
-                    string += '  # {}'.format(
-                        ' '.join(get_normalized(inline_comments))
-                    )
-
-            string += '{})'.format(self.statement.file_artifacts.get('sep',
-                                                                     '\n'))
-
-        return string
-
-
-class VerticalHangingFormatter(Formatter):
-    def formatted(self):
-        leafs = self.unique_leafs
-        string = self.as_string()
-        get_normalized = lambda i: map(
-            operator.attrgetter('normalized'), i
-        )
+        self.init()
 
         all_comments = (
             self.comments + list(itertools.chain(
-                *list(map(operator.attrgetter('comments'), leafs))
+                *list(map(operator.attrgetter('comments'), self.leafs))
             ))
         )
 
         if len(all_comments) == 1:
-            string += '  # {}'.format(' '.join(get_normalized(all_comments)))
+            self.string += '  # {}'\
+                .format(' '.join(self.get_normalized(all_comments)))
 
-        if any((len(string) > 80 and len(leafs) > 1,
+        if any((len(self.string) > 80 and len(self.leafs) > 1,
                 len(all_comments) > 1)):
+            sep = '{}    '.format(self.file_artifacts)
 
-            string = 'from {} import ('.format(self.stem)
-
-            sep = '{0}{1}'.format(self.file_artifacts.get('sep', '\n'),
-                                  ' ' * len(string))
+            self.string = 'from {} import ('.format(self.stem)
 
             if self.comments:
-                string += '  # {}'.format(' '.join(
-                    get_normalized(self.comments)
+                self.string += '  # {}'.format(' '.join(
+                    self.get_normalized(self.comments)
                 ))
 
-            for leaf in leafs:
-                string += sep
+            for leaf in self.leafs:
+                self.string += sep
 
                 first_comments = list(filter(
                     lambda i: i.is_comment_first,
                     leaf.comments
                 ))
                 if first_comments:
-                    string += sep.join(
+                    self.string += sep.join(
                         '# {}'.format(i)
-                        for i in get_normalized(first_comments)
+                        for i in self.get_normalized(first_comments)
                     ) + sep
 
-                string += '{},'.format(leaf.as_string())
+                self.string += '{},'.format(leaf.as_string())
 
                 inline_comments = list(filter(
                     lambda i: not i.is_comment_first,
                     leaf.comments
                 ))
                 if inline_comments:
-                    string += '  # {}'.format(
-                        ' '.join(get_normalized(inline_comments))
+                    self.string += '  # {}'.format(
+                        ' '.join(self.get_normalized(inline_comments))
                     )
 
-            string += '{})'.format(sep)
+            self.string += '{})'.format(self.file_artifacts)
 
-            # Check if lines doesn't exceed 80 characters
-            needs_reformat = False
-            for line in string.split(self.file_artifacts.get('sep', '\n')):
-                if len(line) > 80:
-                    needs_reformat = True
+        return self.string
 
-            if needs_reformat:
-                tab_sep = '{}    '.format(self.file_artifacts.get('sep', '\n'))
-                string = re.sub(sep, tab_sep, string)
 
-        return string
+class VerticalHangingFormatter(Formatter):
+    pass
+    #def format(self):
+        #string = self.statement.as_string()
+        #self.get_normalized = lambda i: map(
+            #operator.attrgetter('normalized'), i
+        #)
+
+        #all_comments = (
+            #self.comments + list(itertools.chain(
+                #*list(map(operator.attrgetter('comments'), self.leafs))
+            #))
+        #)
+
+        #if len(all_comments) == 1:
+            #self.string += '  # {}'.format(' '.join(self.get_normalized(all_comments)))
+
+        #if any((len(self.string) > 80 and len(self.leafs) > 1,
+                #len(all_comments) > 1)):
+
+            #self.string = 'from {} import ('.format(self.stem)
+
+            #sep = '{0}{1}'.format(self.file_artifacts, #' ' * len(self.string))
+
+            #if self.comments:
+                #self.string += '  # {}'.format(' '.join(
+                    #self.get_normalized(self.comments)
+                #))
+
+            #for leaf in self.leafs:
+                #self.string += sep
+
+                #first_comments = list(filter(
+                    #lambda i: i.is_comment_first,
+                    #leaf.comments
+                #))
+                #if first_comments:
+                    #self.string += sep.join(
+                        #'# {}'.format(i)
+                        #for i in self.get_normalized(first_comments)
+                    #) + sep
+
+                #self.string += '{},'.format(leaf.as_string())
+
+                #inline_comments = list(filter(
+                    #lambda i: not i.is_comment_first,
+                    #leaf.comments
+                #))
+                #if inline_comments:
+                    #self.string += '  # {}'.format(
+                        #' '.join(self.get_normalized(inline_comments))
+                    #)
+
+            #self.string += '{})'.format(sep)
+
+            ## Check if lines doesn't exceed 80 characters
+            #needs_reformat = False
+            #for line in self.string.split(self.file_artifacts):
+                #if len(line) > 80:
+                    #needs_reformat = True
+
+            #if needs_reformat:
+                #tab_sep = '{}    '.format(self.file_artifacts)
+                #self.string = re.sub(sep, tab_sep, self.string)
+
+        #return self.string

--- a/importanize/formatters.py
+++ b/importanize/formatters.py
@@ -3,7 +3,6 @@ from __future__ import print_function, unicode_literals
 
 import itertools
 import operator
-import re
 
 
 class Formatter(object):
@@ -27,8 +26,6 @@ class Formatter(object):
 
     def get_normalized(self, i):
         return map(operator.attrgetter('normalized'), i)
-
-
 
 
 class IndentWithTabsFormatter(Formatter):
@@ -99,68 +96,69 @@ class IndentWithTabsFormatter(Formatter):
 
 
 class VerticalHangingFormatter(Formatter):
+    """Alternative formatter used to organize long imports
+
+    Imports are added one by line and aligned with the opening parenthesis,
+    here's a sample output:
+
+    from other.package.subpackage.module.submodule import (  # noqa
+                                                           CONSTANT,
+                                                           Klass,
+                                                           bar,
+                                                           foo,
+                                                           rainbows
+                                                           )
+    """
+
+    def format(self):
+        self.init()
+
+        all_comments = (
+            self.comments + list(itertools.chain(
+                *list(map(operator.attrgetter('comments'), self.leafs))
+            ))
+        )
+
+        if len(all_comments) == 1:
+            self.string += '  # {}'\
+                .format(' '.join(self.get_normalized(all_comments)))
+
+        if any((len(self.string) > 80 and len(self.leafs) > 1,
+                len(all_comments) > 1)):
+            sep = '{}    '.format(self.file_artifacts)
+
+            self.string = 'from {} import ('.format(self.stem)
+
+            if self.comments:
+                self.string += '  # {}'.format(' '.join(
+                    self.get_normalized(self.comments)
+                ))
+
+            for leaf in self.leafs:
+                self.string += sep
+
+                first_comments = list(filter(
+                    lambda i: i.is_comment_first,
+                    leaf.comments
+                ))
+                if first_comments:
+                    self.string += sep.join(
+                        '# {}'.format(i)
+                        for i in self.get_normalized(first_comments)
+                    ) + sep
+
+                self.string += '{},'.format(leaf.as_string())
+
+                inline_comments = list(filter(
+                    lambda i: not i.is_comment_first,
+                    leaf.comments
+                ))
+                if inline_comments:
+                    self.string += '  # {}'.format(
+                        ' '.join(self.get_normalized(inline_comments))
+                    )
+
+            self.string += '{})'.format(self.file_artifacts)
+
+        return self.string
     pass
-    #def format(self):
-        #string = self.statement.as_string()
-        #self.get_normalized = lambda i: map(
-            #operator.attrgetter('normalized'), i
-        #)
-
-        #all_comments = (
-            #self.comments + list(itertools.chain(
-                #*list(map(operator.attrgetter('comments'), self.leafs))
-            #))
-        #)
-
-        #if len(all_comments) == 1:
-            #self.string += '  # {}'.format(' '.join(self.get_normalized(all_comments)))
-
-        #if any((len(self.string) > 80 and len(self.leafs) > 1,
-                #len(all_comments) > 1)):
-
-            #self.string = 'from {} import ('.format(self.stem)
-
-            #sep = '{0}{1}'.format(self.file_artifacts, #' ' * len(self.string))
-
-            #if self.comments:
-                #self.string += '  # {}'.format(' '.join(
-                    #self.get_normalized(self.comments)
-                #))
-
-            #for leaf in self.leafs:
-                #self.string += sep
-
-                #first_comments = list(filter(
-                    #lambda i: i.is_comment_first,
-                    #leaf.comments
-                #))
-                #if first_comments:
-                    #self.string += sep.join(
-                        #'# {}'.format(i)
-                        #for i in self.get_normalized(first_comments)
-                    #) + sep
-
-                #self.string += '{},'.format(leaf.as_string())
-
-                #inline_comments = list(filter(
-                    #lambda i: not i.is_comment_first,
-                    #leaf.comments
-                #))
-                #if inline_comments:
-                    #self.string += '  # {}'.format(
-                        #' '.join(self.get_normalized(inline_comments))
-                    #)
-
-            #self.string += '{})'.format(sep)
-
-            ## Check if lines doesn't exceed 80 characters
-            #needs_reformat = False
-            #for line in self.string.split(self.file_artifacts):
-                #if len(line) > 80:
-                    #needs_reformat = True
-
-            #if needs_reformat:
-                #tab_sep = '{}    '.format(self.file_artifacts)
-                #self.string = re.sub(sep, tab_sep, self.string)
-
-        #return self.string

--- a/importanize/formatters.py
+++ b/importanize/formatters.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function, unicode_literals
+
+import operator
+import itertools
+
+
+class Formatter(object):
+    def __init__(self, statement):
+        self.statement = statement
+
+
+class IndentWithTabsFormatter(Formatter):
+    def format(self):
+        leafs = self.statement.unique_leafs
+        string = self.statement.as_string()
+        get_normalized = lambda i: map(
+            operator.attrgetter('normalized'), i
+        )
+
+        all_comments = (
+            self.statement.comments + list(itertools.chain(
+                *list(map(operator.attrgetter('comments'), leafs))
+            ))
+        )
+
+        if len(all_comments) == 1:
+            string += '  # {}'.format(' '.join(get_normalized(all_comments)))
+
+        if any((len(string) > 80 and len(leafs) > 1,
+                len(all_comments) > 1)):
+            sep = '{}    '.format(self.statement.file_artifacts.get('sep', '\n'))
+
+            string = 'from {} import ('.format(self.statement.stem)
+
+            if self.statement.comments:
+                string += '  # {}'.format(' '.join(
+                    get_normalized(self.statement.comments)
+                ))
+
+            for leaf in leafs:
+                string += sep
+
+                first_comments = list(filter(
+                    lambda i: i.is_comment_first,
+                    leaf.comments
+                ))
+                if first_comments:
+                    string += sep.join(
+                        '# {}'.format(i)
+                        for i in get_normalized(first_comments)
+                    ) + sep
+
+                string += '{},'.format(leaf.as_string())
+
+                inline_comments = list(filter(
+                    lambda i: not i.is_comment_first,
+                    leaf.comments
+                ))
+                if inline_comments:
+                    string += '  # {}'.format(
+                        ' '.join(get_normalized(inline_comments))
+                    )
+
+            string += '{})'.format(self.statement.file_artifacts.get('sep', '\n'))
+
+        return string
+
+
+class VerticalHangingFormatter(Formatter):
+    def formatted(self):
+        leafs = self.unique_leafs
+        string = self.as_string()
+        get_normalized = lambda i: map(
+            operator.attrgetter('normalized'), i
+        )
+
+        all_comments = (
+            self.comments + list(itertools.chain(
+                *list(map(operator.attrgetter('comments'), leafs))
+            ))
+        )
+
+        if len(all_comments) == 1:
+            string += '  # {}'.format(' '.join(get_normalized(all_comments)))
+
+        if any((len(string) > 80 and len(leafs) > 1,
+                len(all_comments) > 1)):
+
+            string = 'from {} import ('.format(self.stem)
+
+            sep = '{0}{1}'.format(self.file_artifacts.get('sep', '\n'),
+                                  ' '*len(string))
+
+            if self.comments:
+                string += '  # {}'.format(' '.join(
+                    get_normalized(self.comments)
+                ))
+
+            for leaf in leafs:
+                string += sep
+
+                first_comments = list(filter(
+                    lambda i: i.is_comment_first,
+                    leaf.comments
+                ))
+                if first_comments:
+                    string += sep.join(
+                        '# {}'.format(i)
+                        for i in get_normalized(first_comments)
+                    ) + sep
+
+                string += '{},'.format(leaf.as_string())
+
+                inline_comments = list(filter(
+                    lambda i: not i.is_comment_first,
+                    leaf.comments
+                ))
+                if inline_comments:
+                    string += '  # {}'.format(
+                        ' '.join(get_normalized(inline_comments))
+                    )
+
+            string += '{})'.format(sep)
+
+            # Check if lines doesn't exceed 80 characters
+            needs_reformat = False
+            for line in string.split(self.file_artifacts.get('sep', '\n')):
+                if len(line) > 80:
+                    needs_reformat = True
+
+            if needs_reformat:
+                tab_sep = '{}    '.format(self.file_artifacts.get('sep', '\n'))
+                string = re.sub(sep, tab_sep, string)
+
+        return string

--- a/importanize/formatters.py
+++ b/importanize/formatters.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, unicode_literals
 
-import operator
 import itertools
+import operator
+import re
 
 
 class Formatter(object):
@@ -29,7 +30,8 @@ class IndentWithTabsFormatter(Formatter):
 
         if any((len(string) > 80 and len(leafs) > 1,
                 len(all_comments) > 1)):
-            sep = '{}    '.format(self.statement.file_artifacts.get('sep', '\n'))
+            sep = '{}    '.format(self.statement.file_artifacts.get('sep',
+                                                                    '\n'))
 
             string = 'from {} import ('.format(self.statement.stem)
 
@@ -62,7 +64,8 @@ class IndentWithTabsFormatter(Formatter):
                         ' '.join(get_normalized(inline_comments))
                     )
 
-            string += '{})'.format(self.statement.file_artifacts.get('sep', '\n'))
+            string += '{})'.format(self.statement.file_artifacts.get('sep',
+                                                                     '\n'))
 
         return string
 
@@ -90,7 +93,7 @@ class VerticalHangingFormatter(Formatter):
             string = 'from {} import ('.format(self.stem)
 
             sep = '{0}{1}'.format(self.file_artifacts.get('sep', '\n'),
-                                  ' '*len(string))
+                                  ' ' * len(string))
 
             if self.comments:
                 string += '  # {}'.format(' '.join(

--- a/importanize/statements.py
+++ b/importanize/statements.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, unicode_literals
-import itertools
 import operator
 import re
 

--- a/importanize/statements.py
+++ b/importanize/statements.py
@@ -6,6 +6,7 @@ import re
 
 from future.utils import python_2_unicode_compatible
 
+from .formatters import IndentWithTabsFormatter
 from .mixin import ComparatorMixin
 from .utils import list_strip
 
@@ -103,12 +104,13 @@ class ImportStatement(ComparatorMixin):
     """
 
     def __init__(self, line_numbers, stem, leafs=None,
-                 comments=None, **kwargs):
+                 comments=None, formatter=IndentWithTabsFormatter, **kwargs):
         self.line_numbers = line_numbers
         self.stem = stem
         self.leafs = leafs or []
         self.comments = comments or []
         self.file_artifacts = kwargs.get('file_artifacts', {})
+        self.formatter = formatter(self)
 
     @property
     def unique_leafs(self):
@@ -136,59 +138,7 @@ class ImportStatement(ComparatorMixin):
             )
 
     def formatted(self):
-        leafs = self.unique_leafs
-        string = self.as_string()
-        get_normalized = lambda i: map(
-            operator.attrgetter('normalized'), i
-        )
-
-        all_comments = (
-            self.comments + list(itertools.chain(
-                *list(map(operator.attrgetter('comments'), leafs))
-            ))
-        )
-
-        if len(all_comments) == 1:
-            string += '  # {}'.format(' '.join(get_normalized(all_comments)))
-
-        if any((len(string) > 80 and len(leafs) > 1,
-                len(all_comments) > 1)):
-            sep = '{}    '.format(self.file_artifacts.get('sep', '\n'))
-
-            string = 'from {} import ('.format(self.stem)
-
-            if self.comments:
-                string += '  # {}'.format(' '.join(
-                    get_normalized(self.comments)
-                ))
-
-            for leaf in leafs:
-                string += sep
-
-                first_comments = list(filter(
-                    lambda i: i.is_comment_first,
-                    leaf.comments
-                ))
-                if first_comments:
-                    string += sep.join(
-                        '# {}'.format(i)
-                        for i in get_normalized(first_comments)
-                    ) + sep
-
-                string += '{},'.format(leaf.as_string())
-
-                inline_comments = list(filter(
-                    lambda i: not i.is_comment_first,
-                    leaf.comments
-                ))
-                if inline_comments:
-                    string += '  # {}'.format(
-                        ' '.join(get_normalized(inline_comments))
-                    )
-
-            string += '{})'.format(self.file_artifacts.get('sep', '\n'))
-
-        return string
+        return self.formatter.format()
 
     def __hash__(self):
         return hash(self.as_string())

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function, unicode_literals
+import unittest
+
+import mock
+
+from importanize.formatters import Formatter, VerticalHangingFormatter
+from importanize.parser import Token
+from importanize.statements import ImportLeaf, ImportStatement
+
+
+#class TestFormatter(unittest.TestCase):
+    #def test_init(self):
+        #actual = Formatter(mock.sentinel.statement)
+        #self.assertEqual(actual.statement, mock.sentinel.statement)
+
+
+class TestIndentWithTabsFormatter(unittest.TestCase):
+    def test_formatted(self):
+        def _test(stem, leafs, expected, sep='\n', comments=None, **kwargs):
+            statement = ImportStatement(
+                list(),
+                stem,
+                list(map((lambda i:
+                          i if isinstance(i, ImportLeaf)
+                          else ImportLeaf(i)),
+                         leafs)),
+                comments=comments,
+                **kwargs
+            )
+            self.assertEqual(statement.formatted(),
+                             sep.join(expected))
+
+        _test('a', [], ['import a'])
+        _test('a', ['b'], ['from a import b'])
+        _test('a' * 40, ['b' * 40],
+              ['from {} import {}'.format('a' * 40, 'b' * 40)])
+        _test('a' * 40, ['b' * 20, 'c' * 20],
+              ['from {} import ('.format('a' * 40),
+               '    {},'.format('b' * 20),
+               '    {},'.format('c' * 20),
+               ')'])
+        _test('a' * 40, ['b' * 20, 'c' * 20],
+              ['from {} import ('.format('a' * 40),
+               '    {},'.format('b' * 20),
+               '    {},'.format('c' * 20),
+               ')'],
+              sep='\r\n',
+              file_artifacts={'sep': '\r\n'})
+        _test('foo', [],
+              ['import foo  # comment'],
+              comments=[Token('# comment')])
+        _test('foo', [ImportLeaf('bar', comments=[Token('#comment')])],
+              ['from foo import bar  # comment'])
+        _test('something', [ImportLeaf('foo'),
+                            ImportLeaf('bar')],
+              ['from something import bar, foo  # noqa'],
+              comments=[Token('# noqa')])
+        _test('foo',
+              [ImportLeaf('bar', comments=[Token('#hello')]),
+               ImportLeaf('rainbows', comments=[Token('#world')]),
+               ImportLeaf('zzz', comments=[Token('#and lots of sleep',
+                                                 is_comment_first=True)])],
+              ['from foo import (  # noqa',
+               '    bar,  # hello',
+               '    rainbows,  # world',
+               '    # and lots of sleep',
+               '    zzz,',
+               ')'],
+              comments=[Token('#noqa')])
+
+
+#class TestVerticalHangingFormatter(unittest.TestCase):
+    #def test_formatted(self):
+        #def _test(stem, leafs, expected, sep='\n', comments=None, **kwargs):
+            #statement = ImportStatement(
+                #list(),
+                #stem,
+                #list(map((lambda i:
+                          #i if isinstance(i, ImportLeaf)
+                          #else ImportLeaf(i)),
+                         #leafs)),
+                #comments=comments,
+                #formatter=VerticalHangingFormatter,
+                #**kwargs
+            #)
+            #self.assertEqual(statement.formatted(),
+                             #sep.join(expected))
+
+        #_test('a', [], ['import a'])
+        #_test('a', ['b'], ['from a import b'])
+        #_test('a' * 40, ['b' * 40],
+              #['from {} import {}'.format('a' * 40, 'b' * 40)])
+        #_test('a' * 40, ['b' * 20, 'c' * 20],
+              #['from {} import ({}'.format('a' * 40, 'b' * 20),
+               #'    {},'.format('c' * 20),
+               #')'])
+        #_test('a' * 40, ['b' * 20, 'c' * 20],
+              #['from {} import ('.format('a' * 40),
+               #'    {},'.format('b' * 20),
+               #'    {},'.format('c' * 20),
+               #')'],
+              #sep='\r\n',
+              #file_artifacts={'sep': '\r\n'})
+        #_test('foo', [],
+              #['import foo  # comment'],
+              #comments=[Token('# comment')])
+        #_test('foo', [ImportLeaf('bar', comments=[Token('#comment')])],
+              #['from foo import bar  # comment'])
+        #_test('something', [ImportLeaf('foo'),
+                            #ImportLeaf('bar')],
+              #['from something import bar, foo  # noqa'],
+              #comments=[Token('# noqa')])
+        #_test('foo',
+              #[ImportLeaf('bar', comments=[Token('#hello')]),
+               #ImportLeaf('rainbows', comments=[Token('#world')]),
+               #ImportLeaf('zzz', comments=[Token('#and lots of sleep',
+                                                 #is_comment_first=True)])],
+              #['from foo import (  # noqa',
+               #'    bar,  # hello',
+               #'    rainbows,  # world',
+               #'    # and lots of sleep',
+               #'    zzz,',
+               #')'],
+              #comments=[Token('#noqa')])

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,62 +1,70 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, unicode_literals
 import unittest
-
-import mock
-
-from importanize.formatters import Formatter, VerticalHangingFormatter
+from importanize.formatters import (
+    Formatter,
+    IndentWithTabsFormatter,
+    VerticalHangingFormatter,
+)
 from importanize.parser import Token
 from importanize.statements import ImportLeaf, ImportStatement
 
+import mock
 
-#class TestFormatter(unittest.TestCase):
-    #def test_init(self):
-        #actual = Formatter(mock.sentinel.statement)
-        #self.assertEqual(actual.statement, mock.sentinel.statement)
+
+def _test(self, stem, leafs, expected, sep='\n', comments=None, **kwargs):
+    statement = ImportStatement(
+        list(),
+        stem,
+        list(map((lambda i:
+                  i if isinstance(i, ImportLeaf)
+                  else ImportLeaf(i)),
+                 leafs)),
+        comments=comments,
+        formatter=self.formatter,
+        **kwargs
+    )
+    self.assertEqual(statement.formatted(),
+                     sep.join(expected))
+
+
+class TestFormatter(unittest.TestCase):
+    def test_init(self):
+        actual = Formatter(mock.sentinel.statement)
+        self.assertEqual(actual.statement, mock.sentinel.statement)
 
 
 class TestIndentWithTabsFormatter(unittest.TestCase):
-    def test_formatted(self):
-        def _test(stem, leafs, expected, sep='\n', comments=None, **kwargs):
-            statement = ImportStatement(
-                list(),
-                stem,
-                list(map((lambda i:
-                          i if isinstance(i, ImportLeaf)
-                          else ImportLeaf(i)),
-                         leafs)),
-                comments=comments,
-                **kwargs
-            )
-            self.assertEqual(statement.formatted(),
-                             sep.join(expected))
+    def setUp(self):
+        self.formatter = IndentWithTabsFormatter
 
-        _test('a', [], ['import a'])
-        _test('a', ['b'], ['from a import b'])
-        _test('a' * 40, ['b' * 40],
+    def test_formatted(self):
+        _test(self, 'a', [], ['import a'])
+        _test(self, 'a', ['b'], ['from a import b'])
+        _test(self, 'a' * 40, ['b' * 40],
               ['from {} import {}'.format('a' * 40, 'b' * 40)])
-        _test('a' * 40, ['b' * 20, 'c' * 20],
+        _test(self, 'a' * 40, ['b' * 20, 'c' * 20],
               ['from {} import ('.format('a' * 40),
                '    {},'.format('b' * 20),
                '    {},'.format('c' * 20),
                ')'])
-        _test('a' * 40, ['b' * 20, 'c' * 20],
+        _test(self, 'a' * 40, ['b' * 20, 'c' * 20],
               ['from {} import ('.format('a' * 40),
                '    {},'.format('b' * 20),
                '    {},'.format('c' * 20),
                ')'],
               sep='\r\n',
               file_artifacts={'sep': '\r\n'})
-        _test('foo', [],
+        _test(self, 'foo', [],
               ['import foo  # comment'],
               comments=[Token('# comment')])
-        _test('foo', [ImportLeaf('bar', comments=[Token('#comment')])],
+        _test(self, 'foo', [ImportLeaf('bar', comments=[Token('#comment')])],
               ['from foo import bar  # comment'])
-        _test('something', [ImportLeaf('foo'),
-                            ImportLeaf('bar')],
+        _test(self, 'something', [ImportLeaf('foo'),
+                                  ImportLeaf('bar')],
               ['from something import bar, foo  # noqa'],
               comments=[Token('# noqa')])
-        _test('foo',
+        _test(self, 'foo',
               [ImportLeaf('bar', comments=[Token('#hello')]),
                ImportLeaf('rainbows', comments=[Token('#world')]),
                ImportLeaf('zzz', comments=[Token('#and lots of sleep',
@@ -70,56 +78,45 @@ class TestIndentWithTabsFormatter(unittest.TestCase):
               comments=[Token('#noqa')])
 
 
-#class TestVerticalHangingFormatter(unittest.TestCase):
-    #def test_formatted(self):
-        #def _test(stem, leafs, expected, sep='\n', comments=None, **kwargs):
-            #statement = ImportStatement(
-                #list(),
-                #stem,
-                #list(map((lambda i:
-                          #i if isinstance(i, ImportLeaf)
-                          #else ImportLeaf(i)),
-                         #leafs)),
-                #comments=comments,
-                #formatter=VerticalHangingFormatter,
-                #**kwargs
-            #)
-            #self.assertEqual(statement.formatted(),
-                             #sep.join(expected))
+class TestVerticalHangingFormatter(unittest.TestCase):
+    def setUp(self):
+        self.formatter = VerticalHangingFormatter
 
-        #_test('a', [], ['import a'])
-        #_test('a', ['b'], ['from a import b'])
-        #_test('a' * 40, ['b' * 40],
-              #['from {} import {}'.format('a' * 40, 'b' * 40)])
-        #_test('a' * 40, ['b' * 20, 'c' * 20],
-              #['from {} import ({}'.format('a' * 40, 'b' * 20),
-               #'    {},'.format('c' * 20),
-               #')'])
-        #_test('a' * 40, ['b' * 20, 'c' * 20],
-              #['from {} import ('.format('a' * 40),
-               #'    {},'.format('b' * 20),
-               #'    {},'.format('c' * 20),
-               #')'],
-              #sep='\r\n',
-              #file_artifacts={'sep': '\r\n'})
-        #_test('foo', [],
-              #['import foo  # comment'],
-              #comments=[Token('# comment')])
-        #_test('foo', [ImportLeaf('bar', comments=[Token('#comment')])],
-              #['from foo import bar  # comment'])
-        #_test('something', [ImportLeaf('foo'),
-                            #ImportLeaf('bar')],
-              #['from something import bar, foo  # noqa'],
-              #comments=[Token('# noqa')])
-        #_test('foo',
-              #[ImportLeaf('bar', comments=[Token('#hello')]),
-               #ImportLeaf('rainbows', comments=[Token('#world')]),
-               #ImportLeaf('zzz', comments=[Token('#and lots of sleep',
-                                                 #is_comment_first=True)])],
-              #['from foo import (  # noqa',
-               #'    bar,  # hello',
-               #'    rainbows,  # world',
-               #'    # and lots of sleep',
-               #'    zzz,',
-               #')'],
-              #comments=[Token('#noqa')])
+    def test_formatted(self):
+        _test(self, 'a', [], ['import a'])
+        _test(self, 'a', ['b'], ['from a import b'])
+        _test(self, 'a' * 40, ['b' * 40],
+              ['from {} import {}'.format('a' * 40, 'b' * 40)])
+        _test(self, 'a' * 40, ['b' * 20, 'c' * 20],
+              ['from {} import ('.format('a' * 40),
+               '    {},'.format('b' * 20),
+               '    {},'.format('c' * 20),
+               ')'])
+        _test(self, 'a' * 40, ['b' * 20, 'c' * 20],
+              ['from {} import ('.format('a' * 40),
+               '    {},'.format('b' * 20),
+               '    {},'.format('c' * 20),
+               ')'],
+              sep='\r\n',
+              file_artifacts={'sep': '\r\n'})
+        _test(self, 'foo', [],
+              ['import foo  # comment'],
+              comments=[Token('# comment')])
+        _test(self, 'foo', [ImportLeaf('bar', comments=[Token('#comment')])],
+              ['from foo import bar  # comment'])
+        _test(self, 'something', [ImportLeaf('foo'),
+                                  ImportLeaf('bar')],
+              ['from something import bar, foo  # noqa'],
+              comments=[Token('# noqa')])
+        _test(self, 'foo',
+              [ImportLeaf('bar', comments=[Token('#hello')]),
+               ImportLeaf('rainbows', comments=[Token('#world')]),
+               ImportLeaf('zzz', comments=[Token('#and lots of sleep',
+                                                 is_comment_first=True)])],
+              ['from foo import (  # noqa',
+               '    bar,  # hello',
+               '    rainbows,  # world',
+               '    # and lots of sleep',
+               '    zzz,',
+               ')'],
+              comments=[Token('#noqa')])

--- a/tests/test_statements.py
+++ b/tests/test_statements.py
@@ -5,6 +5,7 @@ import unittest
 import mock
 import six
 
+from importanize.formatters import IndentWithTabsFormatter
 from importanize.parser import Token
 from importanize.statements import ImportLeaf, ImportStatement
 
@@ -109,6 +110,7 @@ class TestImportStatement(unittest.TestCase):
         self.assertEqual(actual.line_numbers, mock.sentinel.line_numbers)
         self.assertEqual(actual.stem, mock.sentinel.stem)
         self.assertEqual(actual.leafs, [])
+        self.assertIsInstance(actual.formatter, IndentWithTabsFormatter)
 
         actual = ImportStatement(mock.sentinel.line_numbers,
                                  mock.sentinel.stem,

--- a/tox.ini
+++ b/tox.ini
@@ -13,4 +13,4 @@ whitelist_externals =
 
 [flake8]
 exclude = tests/test_data/*
-ignore = E731,W503
+ignore = W503

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,11 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/multinosetests
 commands =
     make check
-deps =
-    -rrequirements-dev.txt
+deps = -rrequirements.txt
+
 whitelist_externals =
     make
 
 [flake8]
 exclude = tests/test_data/*
+ignore = E731,W503

--- a/tox.ini
+++ b/tox.ini
@@ -6,11 +6,12 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/multinosetests
 commands =
     make check
-deps = -rrequirements.txt
+deps =
+    -rrequirements.txt
 
 whitelist_externals =
     make
 
 [flake8]
 exclude = tests/test_data/*
-ignore = W503
+ignore = E731,W503


### PR DESCRIPTION
This is only a draft to see if you'd like to add this feature, tests haven't been changed. What do you think @miki725 ?

TODO

- [ ] add `--formatter` option in the script
- [ ] refactor `formatted()` tests to `test_formatters.py`
- [ ] add new tests for new formatter
- [ ] add some docs with examples of difference in formatters
- [ ] update `README`