### PR TITLE
Fix local path new directory

### DIFF
--- a/importanize/__main__.py
+++ b/importanize/__main__.py
@@ -93,17 +93,21 @@ class Config(dict):
             return cls.default()
 
     @classmethod
-    def find(cls, cwd=pathlib.Path.cwd(), root=None):
+    def find(cls, cwd=pathlib.Path.cwd(), root=None, config=None):
         path = cwd
+        config = config or cls.default()
 
-        while path != pathlib.Path(root or cwd.root):
+        while all([
+            path != pathlib.Path(root or cwd.root),
+            path != pathlib.Path('.')
+        ]):
             config_path = path / IMPORTANIZE_CONFIG
             if config_path.exists():
                 return Config.from_path(config_path)
             else:
                 path = path.parent
 
-        return cls.default()
+        return config
 
     def __str__(self):
         return six.text_type(self.path or '<default pep8>')
@@ -295,7 +299,8 @@ def run(source, config, args, path=None):
         if args.subconfig:
             config = Config.find(
                 cwd=source.parent,
-                root=getattr(config.path, 'parent', None)
+                root=getattr(config.path, 'parent', None),
+                config=config
             ) or config
 
         if config.get('exclude'):

--- a/importanize/__main__.py
+++ b/importanize/__main__.py
@@ -220,7 +220,8 @@ def run_importanize_on_text(text, config, args):
 
     lines = text.splitlines()
     for line_number in sorted(groups.all_line_numbers(), reverse=True):
-        lines.pop(line_number)
+        if lines:
+            lines.pop(line_number)
 
     i = first_import_line_number
     while i is not None and len(lines) > i:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -310,6 +310,22 @@ class TestMain(unittest.TestCase):
         )
         self.assertEqual(config.path, expected_config)
 
+    def test_find_config_current_dir(self):
+        # Instead of the absolute path, assume, user is running importanize
+        # from the current directory.
+
+        expected_config = Path(__file__).parent.parent.joinpath(
+            IMPORTANIZE_CONFIG
+        )
+        # If path is a file, and we have a config for the project and no
+        # subconfig, and we dont find the config for the file, return the
+        # passed config.
+        config = Config.find(
+            Path('tests/test_main.py'),
+            config=Config.from_path(expected_config)
+        )
+        self.assertEqual(config.path, expected_config)
+
     def test_find_config_nonfound(self):
         config = Config.find(Path(Path(__file__).root))
 


### PR DESCRIPTION
Fixes the following current issues with importanize.

1) Running importanize on a newly created directory with a python file gives the following error
 ```bash
 Error running importanize
 Traceback (most recent call last):
   File "/Users/e002582/.virtualenvs/dtweb/lib/python2.7/site-packages/importanize/__main__.py", line 387, in main
     run(p, config, args)
   File "/Users/e002582/.virtualenvs/dtweb/lib/python2.7/site-packages/importanize/__main__.py", line 311, in run
     return run(text, config, args, source)
   File "/Users/e002582/.virtualenvs/dtweb/lib/python2.7/site-packages/importanize/__main__.py", line 261, in run
     organized = run_importanize_on_text(source, config, args)
   File "/Users/e002582/.virtualenvs/dtweb/lib/python2.7/site-packages/importanize/__main__.py", line 226, in run_im
 portanize_on_text
     lines.pop(line_number)
 IndexError: pop from empty list
 ```

2) Running importanize without giving the full path freezes importanize (gets stuck in the while loop). So, if theres a project configuration return it in such cases.
